### PR TITLE
Disable access to gt during competition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ CATKIN_IGNORE
 worlds/generated.world
 Media/models/virtual_maize_field_heightmap.png
 map/*
+gt/*
 launch/robot_spawner.launch
 
 # Ignore generated models
@@ -39,3 +40,4 @@ models/dandelion_*
 
 # Keep specific files
 !map/.gitkeep
+!gt/.gitkeep

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>virtual_maize_field</name>
-  <version>4.3.1</version>
+  <version>4.4.0</version>
   <description>A virtual maize field for agricultural robot simulation in Gazebo.</description>
 
   <maintainer email="info@fieldrobot.com">Field Robot Event Organization</maintainer>

--- a/src/virtual_maize_field/generate_world.py
+++ b/src/virtual_maize_field/generate_world.py
@@ -57,8 +57,8 @@ class WorldGenerator:
         if gazebo_cache_pkg.is_dir():
             rmtree(gazebo_cache_pkg)
 
-    def save_minimap(self) -> None:
-        minimap_file = self.pkg_path / "map/map.png"
+    def save_gt_minimap(self) -> None:
+        minimap_file = self.pkg_path / "gt/map.png"
         self.fgen.minimap.savefig(str(minimap_file), dpi=100)
 
     def save_marker_file(self) -> None:
@@ -83,8 +83,8 @@ class WorldGenerator:
                     ]
                 )
 
-    def save_complete_map(self) -> None:
-        complete_map_file = self.pkg_path / "map/map.csv"
+    def save_gt_map(self) -> None:
+        complete_map_file = self.pkg_path / "gt/map.csv"
         with complete_map_file.open("w") as f:
             writer = csv_writer(f)
             header = ["X", "Y", "kind"]
@@ -194,9 +194,9 @@ def main() -> None:
 
     generator.generate()
     generator.clear_gazebo_cache()
-    generator.save_minimap()
+    generator.save_gt_minimap()
     generator.save_marker_file()
-    generator.save_complete_map()
+    generator.save_gt_map()
     generator.save_launch_file()
 
 


### PR DESCRIPTION
Move ground truth map files (`map.csv` and `map.png`) to a specific folder that will not be mounted to the `robot_container`.