### PR TITLE
Add litter types for mapping

### DIFF
--- a/config/fre22_task_mapping.yaml
+++ b/config/fre22_task_mapping.yaml
@@ -14,3 +14,6 @@ ghost_objects: true
 location_markers: true
 weed_types:
   - dandelion
+litter_types: 
+  - coke_can
+  - retro_pepsi_can

--- a/config/fre22_task_mapping_fast.yaml
+++ b/config/fre22_task_mapping_fast.yaml
@@ -10,8 +10,12 @@ hole_prob: [0.06, 0.06, 0.06, 0.05, 0.03, 0.02, 0.02, 0.01, 0.0, 0.0, 0.0, 0.0]
 hole_size_max: [10, 10, 9, 7, 4, 5, 5, 3, 2, 0, 0, 0]
 ground_resolution: 0.15
 ground_elevation_max: 0.05
+litters: 5
 weeds: 5
 ghost_objects: true
 location_markers: true
 weed_types:
   - dandelion
+litter_types: 
+  - coke_can
+  - retro_pepsi_can

--- a/config/fre22_task_mapping_mini.yaml
+++ b/config/fre22_task_mapping_mini.yaml
@@ -15,3 +15,6 @@ ghost_objects: true
 location_markers: true
 weed_types: 
   - dandelion
+litter_types: 
+  - coke_can
+  - retro_pepsi_can

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>virtual_maize_field</name>
-  <version>4.6.1</version>
+  <version>4.7.0</version>
   <description>A virtual maize field for agricultural robot simulation in Gazebo.</description>
 
   <maintainer email="info@fieldrobot.com">Field Robot Event Organization</maintainer>

--- a/src/virtual_maize_field/world_generator/models.py
+++ b/src/virtual_maize_field/world_generator/models.py
@@ -141,9 +141,13 @@ WEED_MODELS = {
 LITTER_MODELS = {
     "ale": GazeboModel(model_name="ale", default_roll=1.5707963267948966),
     "beer": GazeboModel(model_name="beer", default_roll=1.5707963267948966),
-    "coke_can": GazeboModel(model_name="coke_can", default_roll=1.5707963267948966),
+    "coke_can": GazeboModel(
+        model_name="coke_can", default_roll=1.5707963267948966, default_z=0.025
+    ),
     "retro_pepsi_can": GazeboModel(
-        model_name="retro_pepsi_can", default_roll=1.5707963267948966
+        model_name="retro_pepsi_can",
+        default_roll=1.5707963267948966,
+        default_z=0.025,
     ),
 }
 


### PR DESCRIPTION
We only use cans as litter this year. So limit the litter types to the cans.