### PR TITLE
Add end-of-life to Gazebo Classic branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Virtual Maize Field
-
 > [!IMPORTANT]
 > Gazebo Classic reached [end-of-life](https://community.gazebosim.org/t/gazebo-classic-end-of-life/2563) in January 2025, so this branch will no longer receive updates.
-> 
+
+# Virtual Maize Field
+
 <p float="left" align="middle">
   <img src="misc/FRE-logo.png" width="250">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Virtual Maize Field
 
+> [!IMPORTANT]
+> Gazebo Classic reached [end-of-life](https://community.gazebosim.org/t/gazebo-classic-end-of-life/2563) in January 2025, so this branch will no longer receive updates.
+> 
 <p float="left" align="middle">
   <img src="misc/FRE-logo.png" width="250">
 </p>


### PR DESCRIPTION
Adding warning that Gazebo classic is not supported anymore. Have to add this to `ros2` branch as well.